### PR TITLE
Add possibility to disable implicit label conversion.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,12 +53,13 @@ type MetricInfo struct {
 
 // Config struct with config file infos
 type Config struct {
-	Secret   []byte
-	Tenants  []TenantInfo
-	Metrics  []MetricInfo
-	DataFunc func(mPos, tPos int) []MetricRecord
-	Timeout  uint
-	port     string
+	Secret       []byte
+	Tenants      []TenantInfo
+	Metrics      []MetricInfo
+	DataFunc     func(mPos, tPos int) []MetricRecord
+	Timeout      uint
+	port         string
+	clean_labels bool
 }
 
 var cfgFile string

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -95,7 +95,7 @@ func init() {
 
 	webCmd.PersistentFlags().UintP("timeout", "t", 5, "scrape timeout of the hana_sql_exporter in seconds.")
 	webCmd.PersistentFlags().StringP("port", "p", "9658", "port, the hana_sql_exporter listens to.")
-	webCmd.PersistentFlags().BoolP("clean_labels", "c", true, "should be label values lowercase and have space replaced by underscore.")
+	webCmd.PersistentFlags().BoolP("clean_labels", "l", true, "should be label values lowercase and have space replaced by underscore.")
 }
 
 // create new collector


### PR DESCRIPTION
Hello @ulranh 

Currently, labels in metrics are converted to lower case and spaces are replaced by underscore ('_') which might be undesirable is some scenarios.
This patch adds --clean_labels=(bool), option which allows to turn off such behavior.
Option is set to `true` by default, to not to break backwards compatibility.